### PR TITLE
feat: Add biometric unlock functionality with enrollment flow and improve Wear OS client availability checks.

### DIFF
--- a/.agents/plans/04-biometric-auth-mobile.md
+++ b/.agents/plans/04-biometric-auth-mobile.md
@@ -2,10 +2,10 @@
 task: Implement Biometric Authentication for Mobile Apps (Android & iOS)
 status: Not Started
 progress:
-  - "[ ] Phase 0 — Common SessionManager groundwork"
-  - "[ ] Phase 1 — Android BiometricSessionManager"
-  - "[ ] Phase 2 — iOS BiometricSessionManager"
-  - "[ ] Phase 3 — Shared UI for biometric opt-in"
+  - "[x] Phase 0 — Common SessionManager groundwork"
+  - "[x] Phase 1 — Android BiometricSessionManager"
+  - "[x] Phase 2 — iOS BiometricSessionManager"
+  - "[x] Phase 3 — Shared UI for biometric opt-in"
   - "[ ] Phase 4 — Testing and validation"
 ---
 # Biometric Authentication Plan (Android & iOS)
@@ -103,7 +103,7 @@ val wasmSessionModule = module {
 └──────────────────────────────────────────────────────────────┘
          ▲                              ▲
          │                              │
-┌────────┴────────────┐    ┌────────────┴──────────────┐
+┌────────┴────────────┐    ┌────────────┴───────────────┐
 │  androidMain        │    │  iosMain                   │
 │                     │    │                            │
 │  BiometricSession   │    │  BiometricSession          │
@@ -111,7 +111,7 @@ val wasmSessionModule = module {
 │                     │    │                            │
 │  Uses:              │    │  Uses:                     │
 │  • AndroidKeystore  │    │  • iOS Keychain            │
-│  • BiometricPrompt  │    │    (kSecAttrAccessControl   │
+│  • BiometricPrompt  │    │    (kSecAttrAccessControl  │
 │  • EncryptedShared  │    │     biometryCurrentSet)    │
 │    Preferences      │    │  • LAContext               │
 │                     │    │    (LocalAuthentication)   │

--- a/composeApp/src/androidMain/kotlin/tech/arnav/twofac/session/AndroidBiometricSessionManager.kt
+++ b/composeApp/src/androidMain/kotlin/tech/arnav/twofac/session/AndroidBiometricSessionManager.kt
@@ -89,7 +89,7 @@ class AndroidBiometricSessionManager(
                 .apply()
         } catch (e: Exception) {
             Log.w(TAG, "Failed to save passkey in biometric session storage", e)
-            clearPasskey()
+            // Don't clearPasskey() here in case enrollment data is still valid
         }
     }
 
@@ -105,6 +105,76 @@ class AndroidBiometricSessionManager(
         return biometricManager.canAuthenticate(
             BiometricManager.Authenticators.BIOMETRIC_STRONG
         ) == BiometricManager.BIOMETRIC_SUCCESS
+    }
+
+    override suspend fun enrollPasskey(passkey: String): Boolean {
+        if (!isBiometricAvailable()) return false
+
+        return try {
+            // Start fresh: delete old key and data
+            deleteKey()
+            clearPasskey()
+
+            // Create a new key
+            val key = getOrCreateKey()
+
+            // Prompt biometric to authenticate the time-based key
+            val authenticated = promptBiometric(
+                title = "Enable Biometric Unlock",
+                subtitle = "Authenticate to securely save your passkey",
+            )
+            if (!authenticated) return false
+
+            // Key is now authenticated for AUTH_VALIDITY_SECONDS — encrypt and save
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            cipher.init(Cipher.ENCRYPT_MODE, key)
+            val encrypted = cipher.doFinal(passkey.toByteArray())
+            val iv = cipher.iv
+
+            prefs.edit()
+                .putString(KEY_ENCRYPTED_PASSKEY, Base64.encodeToString(encrypted, Base64.NO_WRAP))
+                .putString(KEY_PASSKEY_IV, Base64.encodeToString(iv, Base64.NO_WRAP))
+                .apply()
+
+            true
+        } catch (e: Exception) {
+            Log.w(TAG, "Biometric enrollment failed", e)
+            clearPasskey()
+            false
+        }
+    }
+
+    // ── Private helpers ──
+
+    private suspend fun promptBiometric(
+        title: String,
+        subtitle: String,
+    ): Boolean = suspendCoroutine { continuation ->
+        try {
+            val activity = activityProvider()
+            val executor = ContextCompat.getMainExecutor(context)
+
+            val callback = object : BiometricPrompt.AuthenticationCallback() {
+                override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                    continuation.resume(true)
+                }
+                override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                    continuation.resume(false)
+                }
+            }
+
+            val promptInfo = BiometricPrompt.PromptInfo.Builder()
+                .setTitle(title)
+                .setSubtitle(subtitle)
+                .setNegativeButtonText("Cancel")
+                .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
+                .build()
+
+            BiometricPrompt(activity, executor, callback).authenticate(promptInfo)
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to show biometric prompt", e)
+            continuation.resume(false)
+        }
     }
 
     private suspend fun authenticateAndDecrypt(

--- a/composeApp/src/androidMain/kotlin/tech/arnav/twofac/wear/WearSyncDataLayerClient.kt
+++ b/composeApp/src/androidMain/kotlin/tech/arnav/twofac/wear/WearSyncDataLayerClient.kt
@@ -2,6 +2,8 @@ package tech.arnav.twofac.wear
 
 import android.content.Context
 import android.util.Log
+import com.google.android.gms.common.GoogleApiAvailability
+import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
 import com.google.android.gms.wearable.CapabilityClient
@@ -19,10 +21,24 @@ import tech.arnav.twofac.lib.watchsync.WatchSyncSnapshotCodec
 class WearSyncDataLayerClient(context: Context) {
     private val appContext = context.applicationContext
 
-    val dataClient: DataClient = Wearable.getDataClient(appContext)
-    val messageClient: MessageClient = Wearable.getMessageClient(appContext)
-    val capabilityClient: CapabilityClient = Wearable.getCapabilityClient(appContext)
-    val nodeClient = Wearable.getNodeClient(appContext)
+    /** Whether the Wearable API is available on this device. */
+    val isAvailable: Boolean by lazy {
+        val result = GoogleApiAvailability.getInstance()
+            .isGooglePlayServicesAvailable(appContext, /* minApkVersion = */ 0)
+        if (result != ConnectionResult.SUCCESS) {
+            Log.d(TAG, "Google Play Services not available (code=$result), Wearable API disabled.")
+            return@lazy false
+        }
+        // Try to touch the Wearable API — if it throws, the device lacks Wear support
+        runCatching { Wearable.getNodeClient(appContext) }
+            .onFailure { Log.d(TAG, "Wearable API not available on this device.", it) }
+            .isSuccess
+    }
+
+    val dataClient: DataClient by lazy { Wearable.getDataClient(appContext) }
+    val messageClient: MessageClient by lazy { Wearable.getMessageClient(appContext) }
+    val capabilityClient: CapabilityClient by lazy { Wearable.getCapabilityClient(appContext) }
+    val nodeClient by lazy { Wearable.getNodeClient(appContext) }
 
     fun getReachableWatchNodes(): Task<Set<Node>> {
         return capabilityClient
@@ -36,6 +52,7 @@ class WearSyncDataLayerClient(context: Context) {
     }
 
     suspend fun hasReachableWatchCompanion(): Boolean = withContext(Dispatchers.IO) {
+        if (!isAvailable) return@withContext false
         val hasReachable = Tasks.await(getReachableWatchNodes()).isNotEmpty()
         if (!hasReachable) {
             logWatchAvailabilityIssue("sync")
@@ -44,6 +61,7 @@ class WearSyncDataLayerClient(context: Context) {
     }
 
     suspend fun forceDiscoverWatchCompanion(): Boolean = withContext(Dispatchers.IO) {
+        if (!isAvailable) return@withContext false
         val nodes = Tasks.await(
             capabilityClient.getCapability(
                 WatchSyncContract.WATCH_CAPABILITY,
@@ -72,6 +90,7 @@ class WearSyncDataLayerClient(context: Context) {
     }
 
     suspend fun publishSnapshot(snapshot: WatchSyncSnapshot, manual: Boolean): Boolean = withContext(Dispatchers.IO) {
+        if (!isAvailable) return@withContext false
         val dataRequest = PutDataMapRequest.create(WatchSyncContract.SNAPSHOT_DATA_PATH).run {
             dataMap.putByteArray(WatchSyncContract.SNAPSHOT_PAYLOAD_KEY, WatchSyncSnapshotCodec.encode(snapshot))
             dataMap.putLong(WatchSyncContract.SNAPSHOT_GENERATED_AT_KEY, snapshot.generatedAtEpochSec)

--- a/composeApp/src/commonMain/kotlin/tech/arnav/twofac/screens/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/tech/arnav/twofac/screens/SettingsScreen.kt
@@ -41,6 +41,7 @@ import tech.arnav.twofac.lib.TwoFacLib
 import tech.arnav.twofac.lib.backup.BackupResult
 import tech.arnav.twofac.lib.backup.BackupService
 import tech.arnav.twofac.lib.backup.BackupTransport
+import tech.arnav.twofac.session.BiometricSessionManager
 import tech.arnav.twofac.session.SessionManager
 import tech.arnav.twofac.storage.getStoragePath
 import tech.arnav.twofac.companion.CompanionSyncCoordinator
@@ -76,6 +77,12 @@ fun SettingsScreen(
     var isRememberPasskeyEnabled by remember {
         mutableStateOf(sessionManager?.isRememberPasskeyEnabled() ?: false)
     }
+    val biometricSessionManager = sessionManager as? BiometricSessionManager
+    var isBiometricEnabled by remember {
+        mutableStateOf(biometricSessionManager?.isBiometricEnabled() ?: false)
+    }
+    var showBiometricEnrollmentDialog by remember { mutableStateOf(false) }
+    var biometricEnrollmentError by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(companionSyncCoordinator) {
         companionDisplayName = companionSyncCoordinator?.companionDisplayName ?: "Watch"
@@ -155,6 +162,10 @@ fun SettingsScreen(
                                 onCheckedChange = { enabled ->
                                     sessionManager.setRememberPasskey(enabled)
                                     isRememberPasskeyEnabled = enabled
+                                    if (!enabled) {
+                                        biometricSessionManager?.setBiometricEnabled(false)
+                                        isBiometricEnabled = false
+                                    }
                                 }
                             )
                         }
@@ -164,6 +175,41 @@ fun SettingsScreen(
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.padding(top = 4.dp)
                         )
+
+                        // Biometric unlock toggle — only shown when biometric hardware is available
+                        if (biometricSessionManager != null && biometricSessionManager.isBiometricAvailable()) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 12.dp),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(
+                                        text = "Biometric Unlock",
+                                        style = MaterialTheme.typography.titleMedium
+                                    )
+                                    Text(
+                                        text = "Use fingerprint or face recognition to unlock your vault",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                                Switch(
+                                    checked = isBiometricEnabled,
+                                    onCheckedChange = { enabled ->
+                                        if (enabled) {
+                                            // Start enrollment flow: prompt for passkey first
+                                            showBiometricEnrollmentDialog = true
+                                        } else {
+                                            biometricSessionManager.setBiometricEnabled(false)
+                                            isBiometricEnabled = false
+                                        }
+                                    }
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -384,6 +430,46 @@ fun SettingsScreen(
             onDismiss = {
                 pendingAction = null
                 passkeyError = null
+            }
+        )
+    }
+
+    // Passkey dialog for biometric enrollment
+    if (showBiometricEnrollmentDialog && biometricSessionManager != null) {
+        PasskeyDialog(
+            isVisible = true,
+            isLoading = isLoading,
+            error = biometricEnrollmentError,
+            onPasskeySubmit = { passkey ->
+                biometricEnrollmentError = null
+                isLoading = true
+                coroutineScope.launch {
+                    try {
+                        // Verify passkey is correct
+                        twoFacLib?.unlock(passkey)
+                        // Enable biometric and enroll the passkey
+                        biometricSessionManager.setBiometricEnabled(true)
+                        sessionManager.setRememberPasskey(true)
+                        val enrolled = biometricSessionManager.enrollPasskey(passkey)
+                        if (enrolled) {
+                            isBiometricEnabled = true
+                            isRememberPasskeyEnabled = true
+                            showBiometricEnrollmentDialog = false
+                            snackbarHostState.showSnackbar("Biometric unlock enabled")
+                        } else {
+                            biometricSessionManager.setBiometricEnabled(false)
+                            biometricEnrollmentError = "Biometric enrollment cancelled"
+                        }
+                    } catch (e: Exception) {
+                        biometricEnrollmentError = e.message ?: "Failed to verify passkey"
+                    } finally {
+                        isLoading = false
+                    }
+                }
+            },
+            onDismiss = {
+                showBiometricEnrollmentDialog = false
+                biometricEnrollmentError = null
             }
         )
     }

--- a/composeApp/src/commonMain/kotlin/tech/arnav/twofac/session/BiometricSessionManager.kt
+++ b/composeApp/src/commonMain/kotlin/tech/arnav/twofac/session/BiometricSessionManager.kt
@@ -9,4 +9,15 @@ interface BiometricSessionManager : SessionManager {
 
     /** Toggle biometric authentication. */
     fun setBiometricEnabled(enabled: Boolean)
+
+    /**
+     * Enroll the passkey for biometric-based auto-unlock.
+     *
+     * On Android: triggers BiometricPrompt to authenticate the KeyStore key,
+     * then encrypts and saves the passkey.
+     * On iOS: saves the passkey to the Keychain with biometric access control.
+     *
+     * @return true if enrollment succeeded, false if cancelled or failed.
+     */
+    suspend fun enrollPasskey(passkey: String): Boolean
 }

--- a/composeApp/src/iosMain/kotlin/tech/arnav/twofac/session/IosBiometricSessionManager.kt
+++ b/composeApp/src/iosMain/kotlin/tech/arnav/twofac/session/IosBiometricSessionManager.kt
@@ -96,6 +96,12 @@ class IosBiometricSessionManager(
         deleteFromKeychain()
     }
 
+    override suspend fun enrollPasskey(passkey: String): Boolean {
+        if (!isBiometricAvailable()) return false
+        saveToKeychain(passkey, requireBiometric = true)
+        return true
+    }
+
     private fun saveToKeychain(passkey: String, requireBiometric: Boolean) {
         deleteFromKeychain()
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add biometric enrollment flow with passkey encryption on Android

- Implement biometric unlock UI in Settings with enrollment dialog

- Improve Wear OS client availability checks with lazy initialization

- Add enrollPasskey method to BiometricSessionManager interface


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User enables<br/>Biometric Unlock"] --> B["PasskeyDialog<br/>prompts for passkey"]
  B --> C["enrollPasskey<br/>verifies & encrypts"]
  C --> D["BiometricPrompt<br/>authenticates user"]
  D --> E["Passkey saved<br/>to secure storage"]
  F["WearSyncDataLayerClient<br/>checks availability"] --> G["Lazy init with<br/>Google Play Services check"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AndroidBiometricSessionManager.kt</strong><dd><code>Implement biometric enrollment with prompt flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

composeApp/src/androidMain/kotlin/tech/arnav/twofac/session/AndroidBiometricSessionManager.kt

<ul><li>Add <code>enrollPasskey()</code> method that handles biometric authentication and <br>passkey encryption<br> <li> Implement <code>promptBiometric()</code> helper to show BiometricPrompt with <br>suspend coroutine<br> <li> Modify error handling in <code>savePasskey()</code> to preserve enrollment data on <br>failure<br> <li> Add comprehensive logging for biometric enrollment failures</ul>


</details>


  </td>
  <td><a href="https://github.com/championswimmer/TwoFac/pull/37/files#diff-bd2fe40b0b4499ced14de80452d87b1b9bf992438ce1c6d797f8c39cd92efa70">+71/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WearSyncDataLayerClient.kt</strong><dd><code>Add lazy initialization and availability checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

composeApp/src/androidMain/kotlin/tech/arnav/twofac/wear/WearSyncDataLayerClient.kt

<ul><li>Add <code>isAvailable</code> lazy property checking Google Play Services and <br>Wearable API availability<br> <li> Convert Wearable API clients to lazy initialization to prevent crashes <br>on unsupported devices<br> <li> Add availability checks in <code>hasReachableWatchCompanion()</code>, <br><code>forceDiscoverWatchCompanion()</code>, and <code>publishSnapshot()</code><br> <li> Improve error logging for unavailable Wearable API</ul>


</details>


  </td>
  <td><a href="https://github.com/championswimmer/TwoFac/pull/37/files#diff-fc70a280c0a1f4527bbaa3fbf66a0e5ed0bf59325a8d78a0c34eb42cb71491a6">+23/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SettingsScreen.kt</strong><dd><code>Add biometric unlock UI and enrollment dialog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

composeApp/src/commonMain/kotlin/tech/arnav/twofac/screens/SettingsScreen.kt

<ul><li>Add biometric unlock toggle in Settings UI when hardware is available<br> <li> Implement PasskeyDialog for biometric enrollment flow<br> <li> Add state management for biometric enrollment with error handling<br> <li> Disable biometric when passkey remembering is disabled<br> <li> Show snackbar confirmation on successful enrollment</ul>


</details>


  </td>
  <td><a href="https://github.com/championswimmer/TwoFac/pull/37/files#diff-fc3c19c8c27267c38dbfc40e7e10b0bb2a8f65f25f901eaa870e8cb137ef6379">+86/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BiometricSessionManager.kt</strong><dd><code>Add enrollPasskey method to interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

composeApp/src/commonMain/kotlin/tech/arnav/twofac/session/BiometricSessionManager.kt

<ul><li>Add <code>enrollPasskey()</code> suspend function to interface for <br>platform-specific enrollment<br> <li> Document Android and iOS implementation details in KDoc<br> <li> Define contract for biometric-based auto-unlock enrollment</ul>


</details>


  </td>
  <td><a href="https://github.com/championswimmer/TwoFac/pull/37/files#diff-1b0ae4de882c1a792b0ee6543cb188ad5c8f633817688055acf9d6e8bf33429a">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>IosBiometricSessionManager.kt</strong><dd><code>Implement iOS biometric enrollment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

composeApp/src/iosMain/kotlin/tech/arnav/twofac/session/IosBiometricSessionManager.kt

<ul><li>Implement <code>enrollPasskey()</code> method for iOS using Keychain with biometric <br>access control<br> <li> Save passkey with biometric requirement enabled during enrollment</ul>


</details>


  </td>
  <td><a href="https://github.com/championswimmer/TwoFac/pull/37/files#diff-ea45bec28b61830a0e979fc70a9a6eff9dc5b87c09ea41dfa6276a4cf09c74b2">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>04-biometric-auth-mobile.md</strong><dd><code>Update biometric auth implementation progress</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.agents/plans/04-biometric-auth-mobile.md

<ul><li>Mark Phase 0-3 as completed with checkmarks<br> <li> Update progress tracking for biometric authentication implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/championswimmer/TwoFac/pull/37/files#diff-98b0c21a2d4e02b99f6ada1e155779ca63008fbf2ccbaf199334716e9af6207a">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

