### PR TITLE
feat: harden PBKDF2 from 200 to 600K iterations with migration

### DIFF
--- a/sharedLib/src/commonMain/kotlin/tech/arnav/twofac/lib/TwoFacLib.kt
+++ b/sharedLib/src/commonMain/kotlin/tech/arnav/twofac/lib/TwoFacLib.kt
@@ -1,8 +1,10 @@
 package tech.arnav.twofac.lib
 
 import dev.whyoleg.cryptography.CryptographyProvider
+import tech.arnav.twofac.lib.crypto.CryptoTools
 import tech.arnav.twofac.lib.crypto.DefaultCryptoTools
 import tech.arnav.twofac.lib.crypto.Encoding.toByteString
+import tech.arnav.twofac.lib.crypto.Encoding.toHexString
 import tech.arnav.twofac.lib.importer.ImportAdapter
 import tech.arnav.twofac.lib.importer.ImportResult
 import tech.arnav.twofac.lib.backup.EncryptedAccountEntry
@@ -82,6 +84,7 @@ class TwoFacLib private constructor(
 
     /**
      * Unlocks the library with the provided passkey and loads accounts into memory
+     * Migrates any accounts using legacy PBKDF2 iteration counts to the current target.
      */
     suspend fun unlock(passKey: String) {
         require(passKey.isNotBlank()) { "Password key cannot be blank" }
@@ -90,6 +93,29 @@ class TwoFacLib private constructor(
         val accounts = storage.getAccountList()
         this.accountList = accounts
         this.storeHasAccounts = accounts.isNotEmpty()
+        migrateIterationsIfNeeded(passKey)
+    }
+
+    private suspend fun migrateIterationsIfNeeded(passKey: String){
+        val accounts = accountList ?: return
+        val needsMigration = accounts.filter { 
+            it.iterations < CryptoTools.TARGET_HASH_ITERATIONS
+        }
+        if (needsMigration.isEmpty()) return
+        
+        for (account in needsMigration){
+            val saltBytes = account.salt.toByteString()
+            val oldKey = cryptoTools.createSigningKey(passKey, saltBytes, account.iterations)
+            val decryptedURI = cryptoTools.decrypt(account.encryptedURI.toByteString(), oldKey.key)
+            val newKey = cryptoTools.createSigningKey(passKey, saltBytes, CryptoTools.TARGET_HASH_ITERATIONS)
+            val reEncryptedURI = cryptoTools.encrypt(newKey.key, decryptedURI)
+            val migrated = account.copy(
+                encryptedURI = reEncryptedURI.toHexString(),
+                iterations = CryptoTools.TARGET_HASH_ITERATIONS,
+            )
+            storage.saveAccount(migrated)
+        }
+        accountList = storage.getAccountList()
     }
 
     /**
@@ -105,7 +131,7 @@ class TwoFacLib private constructor(
         val accounts = accountList ?: error("Account list is not loaded. This should not happen when unlocked.")
         return accounts.map { account ->
             val otp = account.toOTP(
-                cryptoTools.createSigningKey(currentPassKey, account.salt.toByteString()),
+                cryptoTools.createSigningKey(currentPassKey, account.salt.toByteString(), account.iterations),
             )
             account.forDisplay(
                 accountLabel = otp.accountName,
@@ -121,7 +147,7 @@ class TwoFacLib private constructor(
         val accounts = accountList ?: error("Account list is not loaded. This should not happen when unlocked.")
         return accounts.map { account ->
             val otpGen = account.toOTP(
-                cryptoTools.createSigningKey(currentPassKey, account.salt.toByteString()),
+                cryptoTools.createSigningKey(currentPassKey, account.salt.toByteString(), account.iterations),
             )
             val timeNow = Clock.System.now().epochSeconds
             val otpString: String = when (otpGen) {
@@ -243,7 +269,7 @@ class TwoFacLib private constructor(
         val accounts = accountList ?: error("Account list is not loaded. This should not happen when unlocked.")
         return accounts.map { account ->
             account.toDecryptedURI(
-                cryptoTools.createSigningKey(currentPassKey, account.salt.toByteString())
+                cryptoTools.createSigningKey(currentPassKey, account.salt.toByteString(), account.iterations)
             )
         }
     }
@@ -268,6 +294,7 @@ class TwoFacLib private constructor(
             encryptedURI = entry.encryptedURI,
             passKey = passKey,
             salt = entry.salt,
+            iterations = entry.iterations,
         )
     }
 }

--- a/sharedLib/src/commonMain/kotlin/tech/arnav/twofac/lib/backup/BackupPayload.kt
+++ b/sharedLib/src/commonMain/kotlin/tech/arnav/twofac/lib/backup/BackupPayload.kt
@@ -2,6 +2,7 @@ package tech.arnav.twofac.lib.backup
 
 import kotlinx.serialization.Serializable
 import tech.arnav.twofac.lib.PublicApi
+import tech.arnav.twofac.lib.crypto.CryptoTools
 
 /**
  * Versioned payload format for TwoFac backups.
@@ -16,6 +17,7 @@ data class EncryptedAccountEntry(
     val accountLabel: String,
     val salt: String,
     val encryptedURI: String,
+    val iterations: Int = CryptoTools.LEGACY_HASH_ITERATIONS,
 )
 
 @PublicApi

--- a/sharedLib/src/commonMain/kotlin/tech/arnav/twofac/lib/backup/BackupService.kt
+++ b/sharedLib/src/commonMain/kotlin/tech/arnav/twofac/lib/backup/BackupService.kt
@@ -38,6 +38,7 @@ class BackupService(
                         accountLabel = account.accountLabel,
                         salt = account.salt,
                         encryptedURI = account.encryptedURI,
+                        iterations = account.iterations,
                     )
                 }
                 BackupPayload(

--- a/sharedLib/src/commonMain/kotlin/tech/arnav/twofac/lib/crypto/CryptoTools.kt
+++ b/sharedLib/src/commonMain/kotlin/tech/arnav/twofac/lib/crypto/CryptoTools.kt
@@ -54,14 +54,21 @@ interface CryptoTools {
      */
     suspend fun hmacSha(algorithm: Algo, key: ByteString, data: ByteString): ByteString
 
+    companion object {
+        const val LEGACY_HASH_ITERATIONS = 200
+        const val TARGET_HASH_ITERATIONS = 600_000
+    }
+
     /**
      * Derive a key from a password using PBKDF2
      *
      * @param passKey The password to derive the key from
      * @param salt The salt to use for key derivation. If null, a random salt will be generated
+     * @param iterations PBKDF2 iteration count. Defaults to [TARGET_HASH_ITERATIONS] for new keys
+     * Pass [LEGACY_HASH_ITERATIONS] when decrypting accounts created before the migration.
      * @return The derived signing key as a ByteString
      */
-    suspend fun createSigningKey(passKey: String, salt: ByteString? = null): SigningKey
+    suspend fun createSigningKey(passKey: String, salt: ByteString? = null, iterations: Int = TARGET_HASH_ITERATIONS): SigningKey
 
     /**
      * Create a hash of the passKey using the specified SHA algorithm

--- a/sharedLib/src/commonMain/kotlin/tech/arnav/twofac/lib/crypto/DefaultCryptoTools.kt
+++ b/sharedLib/src/commonMain/kotlin/tech/arnav/twofac/lib/crypto/DefaultCryptoTools.kt
@@ -17,8 +17,6 @@ class DefaultCryptoTools(val cryptoProvider: CryptographyProvider) : CryptoTools
     // TODO: make a CryptoConfig class to hold these constants and pass in
     companion object {
         const val SALT_LENGTH = 16 // 128 bits
-        const val HASH_ITERATIONS = 200 // Number of iterations for PBKDF2
-
     }
 
     val hmac = cryptoProvider.get(HMAC)
@@ -38,11 +36,11 @@ class DefaultCryptoTools(val cryptoProvider: CryptographyProvider) : CryptoTools
         return ByteString(signature)
     }
 
-    override suspend fun createSigningKey(passKey: String, salt: ByteString?): CryptoTools.SigningKey {
+    override suspend fun createSigningKey(passKey: String, salt: ByteString?, iterations:Int): CryptoTools.SigningKey {
         // generate a salt
         val saltBytes = salt?.toByteArray() ?: CryptographyRandom.nextBytes(SALT_LENGTH) // 128-bit salt
         // derive a key using PBKDF2
-        val secretDerivation = pbkdf2.secretDerivation(SHA256, HASH_ITERATIONS, 256.bits, saltBytes)
+        val secretDerivation = pbkdf2.secretDerivation(SHA256, iterations, 256.bits, saltBytes)
         val signingKey = secretDerivation.deriveSecretToByteArray(passKey.encodeToByteArray())
         return CryptoTools.SigningKey(key = ByteString(signingKey), salt = ByteString(saltBytes))
     }

--- a/sharedLib/src/commonMain/kotlin/tech/arnav/twofac/lib/storage/StorageUtils.kt
+++ b/sharedLib/src/commonMain/kotlin/tech/arnav/twofac/lib/storage/StorageUtils.kt
@@ -18,7 +18,7 @@ object StorageUtils {
 
     private val cryptoTools = DefaultCryptoTools(CryptographyProvider.Default)
 
-    suspend fun OTP.toStoredAccount(signingKey: CryptoTools.SigningKey): StoredAccount {
+    suspend fun OTP.toStoredAccount(signingKey: CryptoTools.SigningKey, iterations: Int = CryptoTools.TARGET_HASH_ITERATIONS): StoredAccount {
         val accountID = Uuid.fromByteArray(signingKey.salt.toByteArray())
         val otpAuthUriByteString = OtpAuthURI.create(this).encodeToByteString()
 
@@ -27,7 +27,8 @@ object StorageUtils {
             accountID = accountID,
             accountLabel = "${issuer?.let { "$it:" } ?: ""}${accountName}",
             salt = signingKey.salt.toHexString(),
-            encryptedURI = encryptedURI.toHexString()
+            encryptedURI = encryptedURI.toHexString(),
+            iterations = iterations,
         )
     }
 
@@ -41,8 +42,8 @@ object StorageUtils {
         return decryptedURI.decodeToString()
     }
 
-    suspend fun decryptURI(encryptedURI: String, passKey: String, salt: String): String {
-        val signingKey = cryptoTools.createSigningKey(passKey, salt.toByteString())
+    suspend fun decryptURI(encryptedURI: String, passKey: String, salt: String, iterations: Int = CryptoTools.LEGACY_HASH_ITERATIONS): String {
+        val signingKey = cryptoTools.createSigningKey(passKey, salt.toByteString(), iterations)
         val decryptedURI = cryptoTools.decrypt(encryptedURI.toByteString(), signingKey.key)
         return decryptedURI.decodeToString()
     }

--- a/sharedLib/src/commonMain/kotlin/tech/arnav/twofac/lib/storage/StoredAccount.kt
+++ b/sharedLib/src/commonMain/kotlin/tech/arnav/twofac/lib/storage/StoredAccount.kt
@@ -5,6 +5,7 @@ package tech.arnav.twofac.lib.storage
 import kotlinx.serialization.Serializable
 import tech.arnav.twofac.lib.PublicApi
 import kotlin.uuid.ExperimentalUuidApi
+import tech.arnav.twofac.lib.crypto.CryptoTools
 import kotlin.uuid.Uuid
 
 @PublicApi
@@ -14,6 +15,7 @@ data class StoredAccount constructor(
     val accountLabel: String,
     val salt: String,
     val encryptedURI: String,
+    val iterations: Int = CryptoTools.LEGACY_HASH_ITERATIONS,
 ) {
     data class DisplayAccount(
         val accountID: String,

--- a/sharedLib/src/commonTest/kotlin/tech/arnav/twofac/lib/TwoFacLibTest.kt
+++ b/sharedLib/src/commonTest/kotlin/tech/arnav/twofac/lib/TwoFacLibTest.kt
@@ -8,6 +8,16 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import tech.arnav.twofac.lib.crypto.CryptoTools
+import tech.arnav.twofac.lib.crypto.DefaultCryptoTools
+import dev.whyoleg.cryptography.CryptographyProvider
+import tech.arnav.twofac.lib.crypto.Encoding.toByteString
+import tech.arnav.twofac.lib.crypto.Encoding.toHexString
+import tech.arnav.twofac.lib.storage.StoredAccount
+import tech.arnav.twofac.lib.otp.HOTP
+import tech.arnav.twofac.lib.otp.TOTP
+import kotlinx.io.bytestring.encodeToByteString
+import kotlin.uuid.Uuid
 
 class TwoFacLibTest {
 
@@ -167,6 +177,69 @@ class TwoFacLibTest {
 
         assertEquals("alice@example.com", account.accountLabel)
         assertEquals("GitHub", account.issuer)
+    }
+
+
+    @Test
+    fun testUnlockMigratesLegacyIterationAccounts() = runTest {
+        val storage = MemoryStorage()
+        val passkey = "testpasskey"
+        val tools = DefaultCryptoTools(CryptographyProvider.Default)
+
+        // 1. Manually create a legacy account in storage
+        val salt = "000102030405060708090a0b0c0d0e0f"
+        val legacyKey = tools.createSigningKey(passkey, salt.toByteString(), CryptoTools.LEGACY_HASH_ITERATIONS)
+        val uriData = "otpauth://totp/Legacy:user@example.com?secret=JBSWY3DPEHPK3PXP".encodeToByteString()
+        val encryptedURI = tools.encrypt(legacyKey.key, uriData)
+
+        val legacyAccount = StoredAccount(
+            accountID = Uuid.random(),
+            accountLabel = "Legacy",
+            salt = salt,
+            encryptedURI = encryptedURI.toHexString(),
+            iterations = CryptoTools.LEGACY_HASH_ITERATIONS
+        )
+        storage.saveAccount(legacyAccount)
+
+        // 2. Initialise lib and unlock - should trigger migration
+        val lib = TwoFacLib.initialise(storage = storage)
+        lib.unlock(passkey)
+
+        // 3. Verify it was migrated
+        val migratedAccount = storage.getAccountList().single()
+        assertEquals(
+            CryptoTools.TARGET_HASH_ITERATIONS,
+            migratedAccount.iterations,
+            "Account should be migrated to target iterations"
+        )
+
+        // 4. Verify it's still decryptable and generates correct codes
+        val otps = lib.getAllAccountOTPs()
+        assertEquals(1, otps.size)
+        assertEquals("Legacy", otps[0].first.accountLabel)
+        assertTrue(otps[0].second.isNotEmpty())
+    }
+
+    @Test
+    fun testAccountsAreDecryptableAfterIterationMigration() = runTest {
+        val storage = MemoryStorage()
+        val passkey = "testpasskey"
+
+        val lib = TwoFacLib.initialise(storage = storage)
+        lib.unlock(passkey)
+        assertTrue(
+            lib.addAccount(
+                "otpauth://totp/GitHub:alice@example.com?secret=JBSWY3DPEHPK3PXP&issuer=GitHub"
+            )
+        )
+
+        val otps = lib.getAllAccountOTPs()
+        assertEquals(1, otps.size)
+        assertTrue(otps[0].second.isNotEmpty(), "OTP code should be generated after migration")
+
+        val accounts = lib.getAllAccounts()
+        assertEquals(1, accounts.size)
+        assertEquals("GitHub", accounts[0].issuer)
     }
 
     @Test

--- a/sharedLib/src/commonTest/kotlin/tech/arnav/twofac/lib/crypto/CryptoToolsTest.kt
+++ b/sharedLib/src/commonTest/kotlin/tech/arnav/twofac/lib/crypto/CryptoToolsTest.kt
@@ -42,6 +42,45 @@ class CryptoToolsTest {
     }
 
     @Test
+    fun testCreateSigningKeyWithExplicitIterations() = runTest {
+        val tools = DefaultCryptoTools(CryptographyProvider.Default)
+        val data = "my-secret-data".encodeToByteString()
+        val key200 = tools.createSigningKey("password", iterations = CryptoTools.LEGACY_HASH_ITERATIONS)
+        val encrypted200 = tools.encrypt(key200.key, data)
+        val decrypted200 = tools.decrypt(encrypted200, key200.key)
+        assertEquals(data, decrypted200)
+        val key600k = tools.createSigningKey("password", iterations = CryptoTools.TARGET_HASH_ITERATIONS)
+        val encrypted600k = tools.encrypt(key600k.key, data)
+        val decrypted600k = tools.decrypt(encrypted600k, key600k.key)
+        assertEquals(data, decrypted600k)
+    }
+
+    @Test
+    fun testDifferentIterationsProduceDifferentKeys() = runTest {
+        val tools = DefaultCryptoTools(CryptographyProvider.Default)
+        val salt = ByteString(ByteArray(16) { it.toByte() })
+        val key200 = tools.createSigningKey("password", salt, CryptoTools.LEGACY_HASH_ITERATIONS)
+        val key600k = tools.createSigningKey("password", salt, CryptoTools.TARGET_HASH_ITERATIONS)
+        assertTrue(key200.key != key600k.key, "Different iteration counts must produce different keys")
+        assertEquals(key200.salt, key600k.salt, "Salt should be preserved")
+    }
+
+    @Test
+    fun testMigrationRoundTrip() = runTest {
+        val tools = DefaultCryptoTools(CryptographyProvider.Default)
+        val data = "otpauth://totp/Test:user@example.com?secret=JBSWY3DPEHPK3PXP".encodeToByteString()
+        val salt = ByteString(ByteArray(16) { it.toByte() })
+        val oldKey = tools.createSigningKey("password", salt, CryptoTools.LEGACY_HASH_ITERATIONS)
+        val encrypted = tools.encrypt(oldKey.key, data)
+        val decrypted = tools.decrypt(encrypted, oldKey.key)
+        assertEquals(data, decrypted)
+        val newKey = tools.createSigningKey("password", salt, CryptoTools.TARGET_HASH_ITERATIONS)
+        val reEncrypted = tools.encrypt(newKey.key, decrypted)
+        val finalDecrypted = tools.decrypt(reEncrypted, newKey.key)
+        assertEquals(data, finalDecrypted)
+    }
+
+    @Test
     fun testAlgoFromStringKnownValues() {
         assertEquals(CryptoTools.Algo.SHA1,   CryptoTools.Algo.fromString("SHA1"))
         assertEquals(CryptoTools.Algo.SHA256, CryptoTools.Algo.fromString("SHA256"))


### PR DESCRIPTION
PBKDF2-SHA256 key derivation currently uses 200 iterations. The **[OWASP minimum security recommendation](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2:~:text=PBKDF2%2DHMAC%2DSHA256%3A%20600%2C000%20iterations)** for SHA-256 is 600,000 iterations.

This PR proposes hardening the KDF and transparently migrating existing accounts. As part of this, support has been added to seamlessly upgrade stored credentials to the stronger configuration.

---

### Any catch?

In the current architecture, **each account has its own salt**, which means:

- If a user has **50 accounts**, the app must run the _PBKDF2 algorithm_ 50 times at 600,000 iterations each.
- On a modern smartphone, 600k iterations may take approximately _200–500 ms_.
- Multiplied across 50 accounts, the initial `unlock()` call could take **10–25 seconds**.

### Performance impact

Yes, the first unlock after migration will be noticeably slower.

However:
- This cost is **one-time only** during migration.
- Subsequent unlocks will perform similarly to the current implementation.
- The tradeoff significantly improves security, aligning with OWASP recommendations and providing **stronger resistance against brute-force attacks**.