### PR TITLE
Add website-hosted installer for TwoFac CLI

### DIFF
--- a/.agents/plans/36-cli-installer-script-plan.md
+++ b/.agents/plans/36-cli-installer-script-plan.md
@@ -1,13 +1,13 @@
 ---
 name: CLI Installer Script Plan
-status: Planned
+status: Completed
 progress:
-  - "[ ] Phase 0 - Confirm release asset contract and hosting path"
-  - "[ ] Phase 1 - Add website-hosted installer entrypoint"
-  - "[ ] Phase 2 - Implement OS/arch detection and release resolution"
-  - "[ ] Phase 3 - Implement download, extract, and install flow"
-  - "[ ] Phase 4 - Document installer usage in website and repo docs"
-  - "[ ] Phase 5 - Validate static publishing and installer behavior"
+  - "[x] Phase 0 - Confirm release asset contract and hosting path"
+  - "[x] Phase 1 - Add website-hosted installer entrypoint"
+  - "[x] Phase 2 - Implement OS/arch detection and release resolution"
+  - "[x] Phase 3 - Implement download, extract, and install flow"
+  - "[x] Phase 4 - Document installer usage in website and repo docs"
+  - "[x] Phase 5 - Validate static publishing and installer behavior"
 ---
 
 # CLI Installer Script Plan

--- a/.agents/plans/36-cli-installer-script-plan.md
+++ b/.agents/plans/36-cli-installer-script-plan.md
@@ -1,0 +1,312 @@
+---
+name: CLI Installer Script Plan
+status: Planned
+progress:
+  - "[ ] Phase 0 - Confirm release asset contract and hosting path"
+  - "[ ] Phase 1 - Add website-hosted installer entrypoint"
+  - "[ ] Phase 2 - Implement OS/arch detection and release resolution"
+  - "[ ] Phase 3 - Implement download, extract, and install flow"
+  - "[ ] Phase 4 - Document installer usage in website and repo docs"
+  - "[ ] Phase 5 - Validate static publishing and installer behavior"
+---
+
+# CLI Installer Script Plan
+
+## Goal
+
+Add a hosted installer script under `website/` so macOS and Linux users can run:
+
+```bash
+curl -fsSL https://twofac.app/install.sh | bash -s --
+```
+
+and receive the correct `2fac` CLI binary from the latest GitHub Release for `championswimmer/TwoFac`.
+
+Windows remains supported via the existing `.exe` release asset and is out of scope for this shell installer.
+
+---
+
+## Current State
+
+### Release asset contract today
+
+The current release workflow publishes these CLI assets:
+
+- `2fac-linux-x64.tar.gz`
+- `2fac-macos-arm64.tar.gz`
+- `2fac-macos-x64.tar.gz`
+- `2fac-windows-x64.exe`
+
+Important detail: the Unix archives currently contain **`2fac.kexe`** internally, not `2fac`.
+
+### Website hosting model
+
+The website is built with Vite + `vite-ssg` and deployed as static files only. Files placed in `website/public/` are emitted at the root of the built site, so:
+
+- `website/public/install.sh` -> `https://twofac.app/install.sh`
+
+### Current UX gap
+
+The website `DownloadPage.vue` currently sends CLI users to GitHub Releases manually. There is no one-command installer path yet.
+
+---
+
+## Research Summary
+
+### Installer-script hardening
+
+Research on curl-piped shell installers points to a few baseline expectations:
+
+1. Use `bash` intentionally and start with `set -euo pipefail`.
+2. Fail loudly on unsupported OS/arch combinations instead of guessing.
+3. Use `mktemp -d` and `trap` cleanup for downloads/extraction.
+4. Avoid requiring `sudo` for the default path; prefer a user-writable fallback such as `~/.local/bin`.
+5. Download with `curl -fL` so HTTP failures surface immediately.
+
+### Latest-release lookup strategy
+
+There are two reasonable ways to find the latest release:
+
+1. **GitHub REST API** (`/repos/:owner/:repo/releases/latest`)
+2. **GitHub latest redirect** (`/releases/latest`)
+
+For this installer, the best fit is:
+
+- **Primary approach:** resolve the latest tag through the GitHub `releases/latest` redirect
+- **Reason:** the asset names are deterministic, so the script only needs the tag, not full asset metadata
+- **Benefit:** no `jq` or other JSON parser dependency in a bootstrap script
+
+Planned flow:
+
+1. Resolve the effective latest-release tag URL.
+2. Derive the tag (`vX.Y.Z`) from that URL.
+3. Construct the asset download URL directly:
+
+```text
+https://github.com/championswimmer/TwoFac/releases/download/<tag>/<asset-name>
+```
+
+If later testing shows the redirect approach is unreliable in practice, the fallback option is to switch to the REST API for tag resolution only.
+
+### Asset-selection implications
+
+Because the release asset names are already normalized, the installer can use a small explicit matrix:
+
+| OS | Arch | Asset |
+|---|---|---|
+| macOS | arm64 | `2fac-macos-arm64.tar.gz` |
+| macOS | x86_64 | `2fac-macos-x64.tar.gz` |
+| Linux | x86_64 | `2fac-linux-x64.tar.gz` |
+
+Unsupported combinations should fail clearly:
+
+- Linux arm64 / aarch64
+- Windows via this `bash` installer
+- Any other unknown `uname -s` / `uname -m` value
+
+---
+
+## Proposed Implementation
+
+## Phase 0 - Confirm release asset contract and hosting path
+
+1. Treat the current release naming as the contract the installer must support first.
+2. Do **not** block the installer on changing release packaging.
+3. Confirm that `website/public/install.sh` is the simplest path to publish `https://twofac.app/install.sh`.
+4. Keep the script independent of the website app bundle so it remains directly fetchable as a plain shell file.
+
+### Scope guardrail
+
+This first implementation should consume the **existing** release assets as-is. Renaming `2fac.kexe` inside the tarballs can be a separate cleanup task later.
+
+---
+
+## Phase 1 - Add website-hosted installer entrypoint
+
+1. Create `website/public/install.sh`.
+2. Keep the file self-contained and dependency-light.
+3. Ensure the script is served with the exact root path expected by the public install command.
+4. Preserve executable readability in git and static output; execution permission on the hosted file is not required because the script is piped to `bash`.
+
+### Recommended script contract
+
+Support a minimal set of overrides for testing and advanced use:
+
+- `TWOFAC_INSTALL_DIR` — explicit install destination
+- `TWOFAC_RELEASE_TAG` — install a pinned release instead of latest
+- `TWOFAC_REPO` — default `championswimmer/TwoFac`, useful for local forks if needed
+
+These are optional, but they make the installer easier to test without forking the script.
+
+---
+
+## Phase 2 - Implement OS/arch detection and release resolution
+
+1. Detect OS from `uname -s`.
+   - `Darwin` -> `macos`
+   - `Linux` -> `linux`
+2. Detect CPU architecture from `uname -m`.
+   - `x86_64` / `amd64` -> `x64`
+   - `arm64` / `aarch64` -> `arm64`
+3. Map the normalized pair to the release asset name.
+4. Reject unsupported pairs with a direct message that points users to GitHub Releases for manual downloads.
+
+### Planned resolver algorithm
+
+1. If `TWOFAC_RELEASE_TAG` is set, use it directly.
+2. Otherwise resolve the latest tag from:
+
+```text
+https://github.com/championswimmer/TwoFac/releases/latest
+```
+
+3. Build the asset URL from `<tag>` + `<asset-name>`.
+4. Print the resolved version and asset to stderr before download.
+
+### Failure behavior
+
+If the script cannot resolve a release tag or the expected asset does not exist:
+
+1. Exit non-zero.
+2. Print the expected asset name.
+3. Print the release page URL.
+4. Avoid fallback guesses across architectures.
+
+---
+
+## Phase 3 - Implement download, extract, and install flow
+
+1. Verify required tools early:
+   - `curl`
+   - `tar`
+   - `mktemp`
+2. Create a temp directory and register cleanup with `trap`.
+3. Download the chosen asset with `curl -fL`.
+4. Extract Unix tarballs and locate `2fac.kexe`.
+5. Rename the extracted binary to the final installed command name: `2fac`.
+6. Mark it executable and install it atomically.
+
+### Install destination policy
+
+Preferred order:
+
+1. `TWOFAC_INSTALL_DIR` if set
+2. `/usr/local/bin` if writable
+3. `$HOME/.local/bin`
+
+This avoids prompting for `sudo` inside a remote script while still giving a clean global install when permissions already allow it.
+
+### PATH guidance
+
+If the chosen destination is not already on `PATH`, the script should print the exact export line the user needs, for example:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+### Replacement policy
+
+If `2fac` already exists:
+
+1. Overwrite it intentionally with the new binary
+2. Make the replacement atomic via temp file + `mv`
+3. Print the installed version path clearly
+
+### Future-proofing
+
+Even though current Unix assets are `.tar.gz`, structure the script so handling a future direct binary asset would only require a small branch instead of a rewrite.
+
+---
+
+## Phase 4 - Document installer usage in website and repo docs
+
+1. Update `website/src/pages/DownloadPage.vue` to promote the one-line installer for macOS/Linux CLI users.
+2. Add the exact command snippet:
+
+```bash
+curl -fsSL https://twofac.app/install.sh | bash -s --
+```
+
+3. Keep GitHub Releases linked for:
+   - Windows CLI downloads
+   - manual installs
+   - unsupported architectures
+4. Add or update README CLI install guidance so the repo docs and website stay aligned.
+
+### Messaging notes
+
+- Be explicit that the shell installer currently targets **macOS and Linux**
+- Keep Windows on the existing direct-download path
+- Mention that unsupported architectures should use the releases page directly
+
+---
+
+## Phase 5 - Validate static publishing and installer behavior
+
+### Website validation
+
+1. Build the website:
+
+```bash
+cd website
+npm run build
+```
+
+2. Validate SSG output:
+
+```bash
+cd website
+npm run validate:ssg
+```
+
+3. Confirm `dist/install.sh` exists after the build.
+
+### Installer smoke-test matrix
+
+1. **macOS arm64**
+   - resolves `2fac-macos-arm64.tar.gz`
+2. **macOS x64**
+   - resolves `2fac-macos-x64.tar.gz`
+3. **Linux x64**
+   - resolves `2fac-linux-x64.tar.gz`
+4. **Linux arm64**
+   - fails clearly as unsupported
+
+### Behavioral checks
+
+1. Fresh install to `~/.local/bin`
+2. Reinstall over an existing `2fac`
+3. PATH warning when the target directory is not exported
+4. Clear failure if GitHub returns 404 for the resolved asset
+5. Clear failure if `curl` or `tar` is missing
+
+---
+
+## Files Likely Touched
+
+- `website/public/install.sh` (new)
+- `website/src/pages/DownloadPage.vue`
+- `README.md`
+
+Potentially, if follow-up cleanup is desired later:
+
+- `.github/workflows/release.yml` (only if we later decide to rename `2fac.kexe` inside the Unix tarballs)
+
+---
+
+## Out of Scope for This First Pass
+
+- PowerShell installer for Windows
+- Homebrew / apt / yum packaging changes
+- Release-signature or checksum verification unless release assets begin publishing checksum files
+- Reworking the existing CLI release asset naming
+
+---
+
+## Recommended Execution Order
+
+1. Ship `website/public/install.sh` against the current release asset contract.
+2. Update website + README docs to surface the installer command.
+3. Validate the website build emits `dist/install.sh`.
+4. Smoke-test install and reinstall flows on supported platforms.
+5. Only after that, consider cleanup work such as renaming `2fac.kexe` in release archives.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,20 @@ TwoFac/
 
 When `2fac` is run without subcommands in a non-interactive terminal, it prints help and exits.
 
+#### Install the CLI
+
+For macOS (Apple Silicon and Intel) and Linux x86_64, install the latest CLI release with:
+
+```bash
+curl -fsSL https://twofac.app/install.sh | bash -s --
+```
+
+The installer downloads the right asset from the latest GitHub Release and installs it as
+`2fac` into `/usr/local/bin` when writable, or `~/.local/bin` otherwise.
+
+Windows CLI builds remain available as direct downloads from
+[GitHub Releases](https://github.com/championswimmer/TwoFac/releases).
+
 ```text
 2fac
   display
@@ -131,4 +145,3 @@ When `2fac` is run without subcommands in a non-interactive terminal, it prints 
 
 - Root-level commands `2fac add ...` and `2fac backup ...` were removed.
 - Use `2fac accounts add ...` and `2fac storage backup ...` instead.
-

--- a/website/public/install.sh
+++ b/website/public/install.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TWOFAC_REPO="${TWOFAC_REPO:-championswimmer/TwoFac}"
+TWOFAC_RELEASE_TAG="${TWOFAC_RELEASE_TAG:-}"
+TWOFAC_INSTALL_DIR="${TWOFAC_INSTALL_DIR:-}"
+
+RELEASES_BASE_URL="https://github.com/${TWOFAC_REPO}/releases"
+LATEST_RELEASE_URL="${RELEASES_BASE_URL}/latest"
+WORK_DIR=""
+
+log() {
+  printf 'twofac installer: %s\n' "$*" >&2
+}
+
+fail() {
+  log "$*"
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+detect_os() {
+  case "$(uname -s)" in
+    Darwin)
+      printf 'macos\n'
+      ;;
+    Linux)
+      printf 'linux\n'
+      ;;
+    *)
+      fail "Unsupported operating system: $(uname -s). Use ${RELEASES_BASE_URL} for manual downloads."
+      ;;
+  esac
+}
+
+detect_arch() {
+  case "$(uname -m)" in
+    x86_64 | amd64)
+      printf 'x64\n'
+      ;;
+    arm64 | aarch64)
+      printf 'arm64\n'
+      ;;
+    *)
+      fail "Unsupported CPU architecture: $(uname -m). Use ${RELEASES_BASE_URL} for manual downloads."
+      ;;
+  esac
+}
+
+asset_name_for_platform() {
+  case "$1-$2" in
+    macos-arm64)
+      printf '2fac-macos-arm64.tar.gz\n'
+      ;;
+    macos-x64)
+      printf '2fac-macos-x64.tar.gz\n'
+      ;;
+    linux-x64)
+      printf '2fac-linux-x64.tar.gz\n'
+      ;;
+    linux-arm64)
+      fail "Linux arm64 releases are not published yet. Use ${RELEASES_BASE_URL} for manual downloads."
+      ;;
+    *)
+      fail "Unsupported platform: $1/$2. Use ${RELEASES_BASE_URL} for manual downloads."
+      ;;
+  esac
+}
+
+resolve_release_tag_from_redirect() {
+  local effective_url
+  effective_url="$(curl -fsSL -o /dev/null -w '%{url_effective}' "${LATEST_RELEASE_URL}" || true)"
+
+  case "${effective_url}" in
+    */releases/tag/*)
+      printf '%s\n' "${effective_url##*/}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+resolve_release_tag_from_api() {
+  local api_response
+  api_response="$(curl -fsSL -H 'Accept: application/vnd.github+json' "https://api.github.com/repos/${TWOFAC_REPO}/releases/latest" || true)"
+
+  printf '%s\n' "${api_response}" | sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1
+}
+
+resolve_release_tag() {
+  local release_tag
+
+  if [ -n "${TWOFAC_RELEASE_TAG}" ]; then
+    printf '%s\n' "${TWOFAC_RELEASE_TAG}"
+    return 0
+  fi
+
+  release_tag="$(resolve_release_tag_from_redirect || true)"
+  if [ -n "${release_tag}" ]; then
+    printf '%s\n' "${release_tag}"
+    return 0
+  fi
+
+  release_tag="$(resolve_release_tag_from_api || true)"
+  if [ -n "${release_tag}" ]; then
+    printf '%s\n' "${release_tag}"
+    return 0
+  fi
+
+  fail "Could not resolve the latest release tag from GitHub."
+}
+
+choose_install_dir() {
+  if [ -n "${TWOFAC_INSTALL_DIR}" ]; then
+    printf '%s\n' "${TWOFAC_INSTALL_DIR}"
+    return 0
+  fi
+
+  if [ -d /usr/local/bin ] && [ -w /usr/local/bin ]; then
+    printf '/usr/local/bin\n'
+    return 0
+  fi
+
+  [ -n "${HOME:-}" ] || fail "HOME is not set, so a user install directory could not be determined."
+  printf '%s\n' "${HOME}/.local/bin"
+}
+
+path_contains_dir() {
+  case ":${PATH:-}:" in
+    *":$1:"*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+cleanup() {
+  if [ -n "${WORK_DIR:-}" ] && [ -d "${WORK_DIR}" ]; then
+    rm -rf "${WORK_DIR}"
+  fi
+}
+
+main() {
+  local os arch asset_name release_tag asset_url install_dir target_path target_tmp
+  local archive_path extracted_dir extracted_binary staged_binary
+
+  require_command curl
+  require_command tar
+  require_command mktemp
+  require_command sed
+
+  os="$(detect_os)"
+  arch="$(detect_arch)"
+  asset_name="$(asset_name_for_platform "${os}" "${arch}")"
+  release_tag="$(resolve_release_tag)"
+  asset_url="${RELEASES_BASE_URL}/download/${release_tag}/${asset_name}"
+  install_dir="$(choose_install_dir)"
+
+  WORK_DIR="$(mktemp -d)"
+  trap cleanup EXIT
+
+  archive_path="${WORK_DIR}/${asset_name}"
+  extracted_dir="${WORK_DIR}/extract"
+  staged_binary="${WORK_DIR}/2fac"
+
+  log "Resolved ${release_tag} for ${os}/${arch}"
+  log "Downloading ${asset_name}"
+
+  if ! curl -fsSL "${asset_url}" -o "${archive_path}"; then
+    fail "Download failed for ${asset_url}. Visit ${RELEASES_BASE_URL}/tag/${release_tag} for manual downloads."
+  fi
+
+  case "${asset_name}" in
+    *.tar.gz)
+      mkdir -p "${extracted_dir}"
+      tar -xzf "${archive_path}" -C "${extracted_dir}"
+      extracted_binary="${extracted_dir}/2fac.kexe"
+      [ -f "${extracted_binary}" ] || fail "Archive did not contain the expected 2fac.kexe binary."
+      ;;
+    *)
+      extracted_binary="${archive_path}"
+      ;;
+  esac
+
+  mkdir -p "${install_dir}"
+  [ -w "${install_dir}" ] || fail "Install directory is not writable: ${install_dir}. Set TWOFAC_INSTALL_DIR to a writable directory."
+
+  cp "${extracted_binary}" "${staged_binary}"
+  chmod +x "${staged_binary}"
+
+  target_path="${install_dir}/2fac"
+  target_tmp="${install_dir}/.2fac.tmp.$$"
+
+  cp "${staged_binary}" "${target_tmp}"
+  chmod +x "${target_tmp}"
+  mv -f "${target_tmp}" "${target_path}"
+
+  printf 'Installed TwoFac CLI %s to %s\n' "${release_tag}" "${target_path}"
+
+  if ! path_contains_dir "${install_dir}"; then
+    printf 'Add it to your PATH with:\n'
+    printf '  export PATH="%s:$PATH"\n' "${install_dir}"
+  fi
+
+  printf 'Run `2fac --help` to get started.\n'
+}
+
+main "$@"

--- a/website/src/pages/DownloadPage.vue
+++ b/website/src/pages/DownloadPage.vue
@@ -9,14 +9,16 @@ useSEO({
   canonicalPath: '/download',
 })
 
-interface DownloadCard {
-  icon: string
-  name: string
-  description: string
-  link: string
+ interface DownloadCard {
+   icon: string
+   name: string
+   description: string
+   link: string
   linkText: string
-  external?: boolean
-}
+   external?: boolean
+ }
+
+const cliInstallCommand = 'curl -fsSL https://twofac.app/install.sh | bash -s --'
 
 const categories: { title: string; icon: string; cards: DownloadCard[] }[] = [
   {
@@ -168,9 +170,45 @@ const categories: { title: string; icon: string; cards: DownloadCard[] }[] = [
       </div>
     </section>
 
-    <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 sm:py-24 lg:px-8">
-      <!-- Download Categories -->
-      <div class="space-y-16">
+     <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 sm:py-24 lg:px-8">
+       <section
+         class="mb-16 rounded-2xl border border-primary-200 bg-primary-50 p-6 shadow-sm dark:border-primary-900 dark:bg-primary-950/40"
+       >
+         <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+           <div class="max-w-3xl">
+             <p class="text-sm font-semibold uppercase tracking-wide text-primary-700 dark:text-primary-300">
+               CLI installer
+             </p>
+             <h2 class="mt-2 text-2xl font-bold tracking-tight text-secondary-900 dark:text-white">
+               Install the TwoFac CLI in one command
+             </h2>
+             <p class="mt-3 text-secondary-700 dark:text-secondary-300">
+               For macOS (Apple Silicon and Intel) and Linux x86_64, use the hosted installer to
+               fetch the latest CLI release automatically.
+             </p>
+           </div>
+           <a
+             href="https://github.com/championswimmer/TwoFac/releases"
+             target="_blank"
+             rel="noopener noreferrer"
+             class="inline-flex items-center justify-center rounded-lg border border-primary-300 px-4 py-2 text-sm font-semibold text-primary-700 transition-colors hover:bg-primary-100 dark:border-primary-700 dark:text-primary-300 dark:hover:bg-primary-900/60"
+           >
+             Manual downloads
+           </a>
+         </div>
+
+         <div class="mt-5 rounded-xl bg-secondary-950 px-4 py-4 text-sm text-secondary-50">
+           <code class="block overflow-x-auto font-mono">{{ cliInstallCommand }}</code>
+         </div>
+
+         <p class="mt-3 text-sm text-secondary-600 dark:text-secondary-400">
+           Windows CLI binaries are still available from GitHub Releases as direct `.exe`
+           downloads.
+         </p>
+       </section>
+
+       <!-- Download Categories -->
+       <div class="space-y-16">
         <section v-for="category in categories" :key="category.title">
           <h2
             class="text-2xl font-bold tracking-tight text-secondary-900 dark:text-white sm:text-3xl"


### PR DESCRIPTION
## Summary
- add a roadmap for the CLI installer rollout under `.agents/plans/`
- add `website/public/install.sh` to install the latest macOS/Linux CLI release from GitHub Releases
- update the website download page and README to advertise the new curl|bash installer

## Details
- detects macOS arm64/x64 and Linux x64, with clear failures for unsupported platforms
- resolves the latest release tag, downloads the matching asset, extracts `2fac.kexe`, and installs it as `2fac`
- installs into `/usr/local/bin` when writable, otherwise falls back to `~/.local/bin`

## Validation
- smoke-tested the installer into a temp directory and executed the installed binary
- built the website and verified `dist/install.sh` is emitted
- ran `cd website && npm run validate:ssg`